### PR TITLE
Fixing project not being able to load assets when running from IDE.

### DIFF
--- a/source/app/CMakeLists.txt
+++ b/source/app/CMakeLists.txt
@@ -21,6 +21,8 @@ add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
 )
 
 
+set_property(TARGET SnakeMain PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/..")
+
 
 # === Turning off console on release mod
 if(CMAKE_BUILD_TYPE STREQUAL "Release")


### PR DESCRIPTION
The working directory is set to the project directory when you first build the project, the assets are outside of that directory, So I just added a snippet of code to set the working environment as the root directory